### PR TITLE
Allow to derive using conditional_size_of.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "malloc_size_of_derive"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["The Servo Project Developers"]
 license = "MIT/Apache-2.0"
 description = "Crate for Firefox memory reporting, not intended for external use"


### PR DESCRIPTION
This helps with measuring Arc<> and Rc<> which have no primary owner.